### PR TITLE
run with Ghecom on windows if available (NO_JIRA)

### DIFF
--- a/hotspots/calculation.py
+++ b/hotspots/calculation.py
@@ -152,8 +152,6 @@ class ExpBuriedness(object):
 
         scaled_array = resize(out_array, scaled_g.nsteps ,anti_aliasing=False)
 
-
-
         # Future tweaking here
         final_array = scaled_array
         return Grid.array_to_grid(final_array.astype(int), scaled_g)
@@ -789,13 +787,11 @@ class Runner(object):
         """
         method = method.lower()
         if method == 'ghecom':
-            #if sys.platform == 'linux' or sys.platform == 'linux2':
-                if 'GHECOM_EXE' in environ:
-                    self._buriedness_method = method
-                else:
-                    raise EnvironmentError("Must set Ghecom environment variable")
-            #else:
-            #    raise OSError('Ghecom is only supported on linux')
+
+            if 'GHECOM_EXE' in environ:
+                self._buriedness_method = method
+            else:
+                raise EnvironmentError("Must set Ghecom environment variable to use Ghecom")
 
         elif method == 'ghecom_internal':
             self._buriedness_method = method

--- a/hotspots/calculation.py
+++ b/hotspots/calculation.py
@@ -24,7 +24,11 @@ import tempfile
 import time
 from functools import reduce
 from os import system, environ
-from os.path import join
+from os.path import join, dirname
+
+ghecom =join(dirname(dirname(__file__)),"win_ghecom/Ghecom.exe")
+if os.path.exists(ghecom) and not 'GHECOM_EXE' in environ:
+    environ['GHECOM_EXE'] = ghecom
 
 import numpy as np
 import pkg_resources
@@ -785,13 +789,13 @@ class Runner(object):
         """
         method = method.lower()
         if method == 'ghecom':
-            if sys.platform == 'linux' or sys.platform == 'linux2':
+            #if sys.platform == 'linux' or sys.platform == 'linux2':
                 if 'GHECOM_EXE' in environ:
                     self._buriedness_method = method
                 else:
                     raise EnvironmentError("Must set Ghecom environment variable")
-            else:
-                raise OSError('Ghecom is only supported on linux')
+            #else:
+            #    raise OSError('Ghecom is only supported on linux')
 
         elif method == 'ghecom_internal':
             self._buriedness_method = method
@@ -1151,6 +1155,8 @@ class Runner(object):
         protoss = False
 
         tmp = tempfile.mkdtemp()
+        if clear_tmp is False:
+            print("Detailed output written to",tmp)
         # if  protoss is True:
         #     protoss = Protoss(out_dir=tmp)
         #     self.protein = protoss.add_hydrogens(pdb_code).protein


### PR DESCRIPTION
These changes allow Ghecom to be used on windows, if you have a compiled version of Ghecom for windows in a folder win_ghecom.