### PR TITLE
New API has a differnt SWIG so bindings have changed (NO_JIRA)

### DIFF
--- a/hotspots/pharmacophore_extension.py
+++ b/hotspots/pharmacophore_extension.py
@@ -905,7 +905,10 @@ class FeatureDefinition(Pharmacophore.FeatureDefinition):
         super().__init__(_feature_def=_feature_def)
 
     def detect_features(self, crystal):
-        _csv = ChemistryLib.CrystalStructureView_instantiate(crystal._crystal)
+        try:
+            _csv = ChemistryLib.CrystalStructureView_instantiate(crystal._crystal) # Legacy API SWIG bindings
+        except AttributeError: 
+            _csv = ChemistryLib.CrystalStructureView.instantiate(crystal._crystal) # Newer CSD python API SWIG bindings (from 3.3.1)
         _ssc = MotifPharmacophoreLib.MotifPharmacophoreSearchStructureCreator()
         _ssc.register_components_from_feature_definitions((self._feature_def,))
         _mss = _ssc.search_structure(_csv)


### PR DESCRIPTION
The pharmacophore extension needs a tweak for the latest CSD API